### PR TITLE
Update make.sh Removed unnecessary bsc flag

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -36,7 +36,7 @@
 
 BSC="bsc"
 BSCFLAGS="-keep-fires -cross-info -aggressive-conditions \
-          -wait-for-license -suppress-warnings G0043 \
+          -suppress-warnings G0043 \
           -steps-warn-interval 300000"
 SUFFIXES=
 


### PR DESCRIPTION
A flag that no longer exists because bsc now open source is, was removed